### PR TITLE
fix: import cron-parser default

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,7 +11,6 @@ jobs:
     name: Node.js
     uses: node-modules/github-actions/.github/workflows/node-test.yml@master
     with:
-      os: 'ubuntu-latest'
-      version: '18, 20, 22'
+      version: '18.19.0, 18, 20, 22, 23'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # @eggjs/schedule
 
 [![NPM version][npm-image]][npm-url]
-[![Node.js CI](https://github.com/eggjs/egg-schedule/actions/workflows/nodejs.yml/badge.svg)](https://github.com/eggjs/egg-schedule/actions/workflows/nodejs.yml)
+[![Node.js CI](https://github.com/eggjs/schedule/actions/workflows/nodejs.yml/badge.svg)](https://github.com/eggjs/schedule/actions/workflows/nodejs.yml)
 [![Test coverage][codecov-image]][codecov-url]
 [![Known Vulnerabilities][snyk-image]][snyk-url]
 [![npm download][download-image]][download-url]
@@ -9,8 +9,8 @@
 
 [npm-image]: https://img.shields.io/npm/v/@eggjs/schedule.svg?style=flat-square
 [npm-url]: https://npmjs.org/package/@eggjs/schedule
-[codecov-image]: https://codecov.io/github/eggjs/egg-schedule/coverage.svg?branch=master
-[codecov-url]: https://codecov.io/github/eggjs/egg-schedule?branch=master
+[codecov-image]: https://codecov.io/github/eggjs/schedule/coverage.svg?branch=master
+[codecov-url]: https://codecov.io/github/eggjs/schedule?branch=master
 [snyk-image]: https://snyk.io/test/npm/@eggjs/schedule/badge.svg?style=flat-square
 [snyk-url]: https://snyk.io/test/npm/@eggjs/schedule
 [download-image]: https://img.shields.io/npm/dm/@eggjs/schedule.svg?style=flat-square
@@ -252,7 +252,7 @@ export default (app: Application) => {
 
 ### Logging
 
-See `${appInfo.root}/logs/{app_name}/egg-schedule.log` which provided by [config.customLogger.scheduleLogger](https://github.com/eggjs/egg-schedule/blob/master/config/config.default.ts).
+See `${appInfo.root}/logs/{app_name}/egg-schedule.log` which provided by [config.customLogger.scheduleLogger](https://github.com/eggjs/schedule/blob/master/src/config/config.default.ts).
 
 ```ts
 // config/config.default.ts
@@ -304,10 +304,10 @@ Please open an issue [here](https://github.com/eggjs/egg/issues).
 
 ## License
 
-[MIT](https://github.com/eggjs/egg-schedule/blob/master/LICENSE)
+[MIT](LICENSE)
 
 ## Contributors
 
-[![Contributors](https://contrib.rocks/image?repo=eggjs/egg-schedule)](https://github.com/eggjs/egg-schedule/graphs/contributors)
+[![Contributors](https://contrib.rocks/image?repo=eggjs/schedule)](https://github.com/eggjs/schedule/graphs/contributors)
 
 Made with [contributors-img](https://contrib.rocks).

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:eggjs/egg-schedule.git"
+    "url": "git@github.com:eggjs/schedule.git"
   },
   "keywords": [
     "egg",

--- a/src/lib/strategy/timer.ts
+++ b/src/lib/strategy/timer.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
-import { parseExpression, type CronExpression } from 'cron-parser';
+import type { CronExpression } from 'cron-parser';
+import cronParser from 'cron-parser';
 import { ms } from 'humanize-ms';
 import safeTimers from 'safe-timers';
 import { logDate } from 'utility';
@@ -20,7 +21,7 @@ export abstract class TimerStrategy extends BaseStrategy {
     // init cron parser
     if (cron) {
       try {
-        this.cronInstance = parseExpression(cron, cronOptions);
+        this.cronInstance = cronParser.parseExpression(cron, cronOptions);
       } catch (err: any) {
         throw new TypeError(
           `[@eggjs/schedule] ${this.key} parse cron instruction(${cron}) error: ${err.message}`,


### PR DESCRIPTION
```bash
The requested module 'cron-parser' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'cron-parser';
const { parseExpression } = pkg;
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for cron expression parsing, ensuring clearer error messages.

- **Chores**
	- Updated import statements for better clarity and organization.
	- Updated repository URLs in documentation and configuration files for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->